### PR TITLE
Update README regarding component registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ const comp = {
 const { vNode, destroy, el } = mount(comp, { props: { name: 'world' } })
 ```
 
+If the component is defined in a `.vue` file and only created programmatically,
+you may need to import and register it to avoid its template being removed from
+prod builds during tree shaking.  For example:
+
+```js
+import MyComponent from "./MyComponent.vue";
+const app = createApp(App).use(router);
+app.component("MyComponent", MyComponent);
+```
+
 ## api
 
 #### `mount(component, { props, children, element, app })`


### PR DESCRIPTION
Vue 3 + Vite was removing the template on prod, resulting in empty components being mounted.

Hopefully this note saves others some frustration.  I spent a couple hours figuring out why my components were working on dev but not prod.

And thank you for this handy helper module!  This should be built into Vue, in my opinion.